### PR TITLE
Scripts for API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,12 @@ Following scripts helps with commonly used mass operations.
 
 - [bundle.sh](scripts/bundle.sh): Bundles all repositories which contains Gemfile
 - [update.sh](scripts/update.sh): Bundles repositories with Gemfile, runs npm build on UI, insights-chrome and insights-proxy repositories and runs migrations on `topological_inventory-core` and `sources-api`
+
+## Calling APIs
+
+[API directory](scripts/api) contains scripts for querying Sources API and Tp-Inv API.  
+They can be used directly from command line like:
+- `cd scripts`
+- `api/sources/get sources`
+- response can be parsed with *jq* utility: `api/sources/get sources | jq '.'`
+Or called from script with the same parameters, see [examples.sh](scripts/api/examples.sh)

--- a/scripts/api/common.sh
+++ b/scripts/api/common.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+source "config.sh"
+
+plain_rh_identity="{\"identity\":{\"account_number\":\"${MY_GITHUB_NAME}\"}, \"internal\": {\"org_id\": \"54321\"}}"
+
+# base64 can split output to more lines, forbid it with one of following
+# depends on base64 version:
+export X_RH_IDENTITY=$(echo ${plain_rh_identity} | base64 --wrap=0)
+# export X_RH_IDENTITY=$(echo ${plain_rh_identity} | base64)
+# export X_RH_IDENTITY=$(echo ${plain_rh_identity} | base64 --break=0)
+
+# Usage: topological_api_get <path>
+# Example: topological_api_get "source_types?filter[name]=mock"
+function topological_api_get {
+    if [[ -z $2 ]]; then
+        api_path=${TOPOLOGICAL_INVENTORY_API_BASE_PATH}
+    else
+        api_path=$2
+    fi
+    curl -H "x-rh-identity: ${X_RH_IDENTITY}" \
+         --silent \
+        "${TOPOLOGICAL_INVENTORY_API_SERVICE_HOST}:${TOPOLOGICAL_INVENTORY_API_SERVICE_PORT}/${api_path}/$1"
+}
+
+# Usage: api_post <path> <data>
+# Example: api_post "sources" "{\"name\":\"Mock Source 1\",\"source_type_id\":\"4\"}"
+function topological_api_post {
+    curl --request POST \
+         --header "Content-Type: application/json" \
+         --header "x-rh-identity: ${X_RH_IDENTITY}" \
+         --data "$2" \
+         --silent \
+         "${TOPOLOGICAL_INVENTORY_API_SERVICE_HOST}:${TOPOLOGICAL_INVENTORY_API_SERVICE_PORT}/${TOPOLOGICAL_INVENTORY_API_BASE_PATH}/$1"
+}
+
+# Usage: api_post <path> <data>
+# Example: api_post "sources" "{\"name\":\"Mock Source 1\",\"source_type_id\":\"4\"}"
+function topological_api_patch {
+    curl --request PATCH \
+         --header "Content-Type: application/json" \
+         --header "x-rh-identity: ${X_RH_IDENTITY}" \
+         --data "$2" \
+         --silent \
+         "${TOPOLOGICAL_INVENTORY_API_SERVICE_HOST}:${TOPOLOGICAL_INVENTORY_API_SERVICE_PORT}/${TOPOLOGICAL_INVENTORY_API_BASE_PATH}/$1"
+}
+
+# Usage: api_delete <path>
+# Example: api_delete "sources/1"
+function topological_api_delete {
+    curl --request DELETE \
+         --header "x-rh-identity: ${X_RH_IDENTITY}" \
+         --silent \
+         "${TOPOLOGICAL_INVENTORY_API_SERVICE_HOST}:${TOPOLOGICAL_INVENTORY_API_SERVICE_PORT}/${TOPOLOGICAL_INVENTORY_API_BASE_PATH}/$1"
+}
+
+# Usage: api_get <path>
+# Example: api_get "source_types?filter[name]=mock"
+function sources_api_get {
+    if [[ -z $2 ]]; then
+        api_path=${SOURCES_API_BASE_PATH}
+    else
+        api_path=$2
+    fi
+    curl -H "x-rh-identity: ${X_RH_IDENTITY}" \
+         --silent \
+        "${SOURCES_HOST}:${SOURCES_PORT}/${api_path}/$1"
+}
+
+# Usage: api_post <path> <data>
+# Example: api_post "sources" "{\"name\":\"Mock Source 1\",\"source_type_id\":\"4\"}"
+function sources_api_post {
+    curl --request POST \
+         --header "Content-Type: application/json" \
+         --header "x-rh-identity: ${X_RH_IDENTITY}" \
+         --data "$2" \
+         --silent \
+         "${SOURCES_HOST}:${SOURCES_PORT}/${SOURCES_API_BASE_PATH}/$1"
+}
+
+# Usage: api_post <path> <data>
+# Example: api_post "sources" "{\"name\":\"Mock Source 1\",\"source_type_id\":\"4\"}"
+function sources_api_patch {
+  echo "1: ($1)"
+  echo "2: ($2)"
+   curl --request PATCH \
+         --header "Content-Type: application/json" \
+         --header "x-rh-identity: ${X_RH_IDENTITY}" \
+         --data "$2" \
+         --silent \
+         "${SOURCES_HOST}:${SOURCES_PORT}/${SOURCES_API_BASE_PATH}/$1"
+}
+
+# Usage: api_delete <path>
+# Example: api_delete "sources/1"
+function sources_api_delete {
+    curl --request DELETE \
+         --header "x-rh-identity: ${X_RH_IDENTITY}" \
+         --silent \
+         "${SOURCES_HOST}:${SOURCES_PORT}/${SOURCES_API_BASE_PATH}/$1"
+}
+
+######################################
+# @param api_get response
+function records_count {
+    local cnt=`echo $1 | jq '.meta.count'`
+    echo ${cnt}
+}

--- a/scripts/api/examples.sh
+++ b/scripts/api/examples.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+source "api/common.sh"
+
+#
+# LIST tenants ------------------
+#
+# sources_api_get "tenants" "internal/v1.0"
+# echo ""
+# topological_api_get "tenants" "internal/v0.0"
+# echo ""
+#
+# SOURCES --------------------
+#
+# GET Source Type
+# response=`sources_api_get "source_types?filter[name]=amazon"`
+# echo ${response} | jq '.'
+#
+# GET Sources
+# sources_api_get 'sources'
+# echo ""
+# topological_api_get 'sources'
+# echo ""
+
+# CREATE Source
+# sources_api_post "sources" "{\"name\":\"Mock Source 1\",\"source_type_id\":\"4\"}"
+# echo ""
+#
+
+# UPDATE Source
+# sources_api_patch "sources/2" "{\"name\": \"Openshift Source\"}"
+# echo ""
+#
+
+# DELETE Source
+# sources_api_delete "sources/1"
+# echo ""
+#
+
+# APPLICATIONS (complex filter) -----
+
+# GET applications which must be added (at least 1) to Source for creating Collector's pod
+# sources_api_get "applications?filter[application_type_id][eq][]=1&filter[application_type_id][eq][]=3"
+# echo ""
+
+# GRAPHQL -----------------------
+
+# sources_api_post "graphql" "{\"query\": \"{ sources { id, created_at, source_type_id, name, tenant, uid, updated_at applications { application_type_id, id }, endpoints { id, scheme, host, port, path } }}\"}"
+
+
+# CATALOG ORDERING --------------
+# Job template
+# topological_api_post "service_plans/2/order" "{\"service_parameters\":{\"username\":\"mslemr\",\"quest\":\"Test Topology\",\"airspeed\":50},\"provider_control_parameters\":{}}"
+
+# Workflow Job template
+# topological_api_post "service_plans/5/order" "{\"service_parameters\":{\"dev_null\":\"Yes\"},\"provider_control_parameters\":{}}"

--- a/scripts/api/sources/delete
+++ b/scripts/api/sources/delete
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source "api/common.sh"
+sources_api_delete $1

--- a/scripts/api/sources/get
+++ b/scripts/api/sources/get
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source "api/common.sh"
+sources_api_get $1

--- a/scripts/api/sources/patch
+++ b/scripts/api/sources/patch
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source "api/common.sh"
+sources_api_patch $1 "$2"

--- a/scripts/api/sources/post
+++ b/scripts/api/sources/post
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source "api/common.sh"
+sources_api_post $1 "$2"

--- a/scripts/api/topological/delete
+++ b/scripts/api/topological/delete
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source "api/common.sh"
+topological_api_delete $1

--- a/scripts/api/topological/get
+++ b/scripts/api/topological/get
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source "api/common.sh"
+topological_api_get $1

--- a/scripts/api/topological/patch
+++ b/scripts/api/topological/patch
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source "api/common.sh"
+topological_api_patch $1 "$2"

--- a/scripts/api/topological/post
+++ b/scripts/api/topological/post
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source "api/common.sh"
+topological_api_post $1 "$2"

--- a/scripts/config.default.sh
+++ b/scripts/config.default.sh
@@ -52,6 +52,9 @@ export METRICS_PORT=0
 export RVM_RUBY_VERSION_TP_INV="2.5.3"
 export RVM_GEMSET_NAME_TP_INV="tp-inv"
 
+# Uncomment if you want to disable tenancy
+# export BYPASS_TENANCY=1
+
 # Topological Inventory Persister
 export PERSISTER_DIR="$root_dir/topological_inventory-persister"
 
@@ -69,15 +72,16 @@ export TOPOLOGICAL_API_DIR="$root_dir/topological_inventory-api"
 export TOPOLOGICAL_INVENTORY_API_SERVICE_HOST="http://localhost" # used by openshift operations
 export TOPOLOGICAL_INVENTORY_API_SERVICE_PORT=3001
 export TOPOLOGICAL_INVENTORY_URL="http://localhost:3001"
-
-# Uncomment if you want to enable tenancy
-# export BYPASS_TENANCY=1
+# - Used by api scripts
+export TOPOLOGICAL_INVENTORY_API_BASE_PATH="api/topological-inventory/v1.0"
 
 # Sources API service
 export SOURCES_API_DIR="$root_dir/sources-api"
 export SOURCES_SCHEME="http"
 export SOURCES_HOST="localhost"
 export SOURCES_PORT="3002"
+# - Used by api scripts
+export SOURCES_API_BASE_PATH="api/sources/v1.0"
 
 # Mock Source
 export MOCK_SOURCE_DIR="$root_dir/topological_inventory-mock_source"


### PR DESCRIPTION
## Calling APIs

API directory contains scripts for querying Sources API and Tp-Inv API.  
They can be used directly from command line like:
- `cd scripts`
- `api/topological/get sources`
- `api/sources/patch "sources/2" "{\"name\": \"OpenShift Source\"}"`
- response can be parsed with *jq* utility: `api/sources/get sources | jq '.'`

Or requests can be called from bash script with the same parameters, see **_scripts/api/examples.sh_**
