### PR TITLE
Switch Ingress API svc from Rack to Rails app

### DIFF
--- a/scripts/services/ingress-api.sh
+++ b/scripts/services/ingress-api.sh
@@ -5,5 +5,5 @@ source config.sh
 source init-common.sh
 
 cd $INGRESS_API_DIR
-bundle exec rackup
+env QUEUE_HOST=${QUEUE_HOST} QUEUE_PORT=${QUEUE_PORT} rails s -p 9292
 


### PR DESCRIPTION
Ingress API as a Rack app is deprecated for a long time. Using Rails instead