### PR TITLE
Split ACCOUNT_NUMBER and GITHUB_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Default values are filled in [config.default.sh](scripts/config.default.sh).
 - Redefine values in `config.sh`:    
   - Your github name (_MY_GITHUB_NAME_)
   - Your github token (_MY_GITHUB_TOKEN_)
+  - Your account number (_ACCOUNT_NUMBER_) (to account number you're using to log to CI server)
   - Your root directory for repositories (_root_dir_)
   - URL to kafka archive (see chapter above) (_KAFKA_INSTALL_URL_)
   - RVM ruby version you want to use (if using rvm) (_RVM_RUBY_VERSION_TP_INV_)

--- a/scripts/api/common.sh
+++ b/scripts/api/common.sh
@@ -2,7 +2,7 @@
 
 source "config.sh"
 
-plain_rh_identity="{\"identity\":{\"account_number\":\"${MY_GITHUB_NAME}\",\"user\": {\"is_org_admin\":true}}, \"internal\": {\"org_id\": \"54321\"}}"
+plain_rh_identity="{\"identity\":{\"account_number\":\"${ACCOUNT_NUMBER}\",\"user\": {\"is_org_admin\":true}}, \"internal\": {\"org_id\": \"54321\"}}"
 
 # base64 can split output to more lines, forbid it with one of following
 # depends on base64 version:

--- a/scripts/api/examples.sh
+++ b/scripts/api/examples.sh
@@ -44,7 +44,7 @@ source "api/common.sh"
 
 # GRAPHQL -----------------------
 
-# sources_api_post "graphql" "{\"query\": \"{ sources { id, created_at, source_type_id, name, tenant, uid, updated_at applications { application_type_id, id }, endpoints { id, scheme, host, port, path } }}\"}"
+ sources_api_post "graphql" "{\"query\": \"{ sources { id, created_at, source_type_id, name, tenant, uid, updated_at applications { application_type_id, id }, endpoints { id, scheme, host, port, path } }}\"}"
 
 
 # CATALOG ORDERING --------------

--- a/scripts/config.default.sh
+++ b/scripts/config.default.sh
@@ -29,8 +29,7 @@ export MY_GITHUB_TOKEN=""
 # Account number is used to http auth header.
 # It equals Tenant.external_tenant db value
 # If you log in to CI/QA/Prod server, you can see account number in dropbox under user name
-# Set to github_name for backwards compatibility
-export ACCOUNT_NUMBER=${MY_GITHUB_NAME}
+export ACCOUNT_NUMBER=""
 # Variable for HTTP request header x-rh-identity.
 # Requests authenticated against Tenant.external_tenant
 export X_RH_IDENTITY=$(echo "{\"identity\":{\"account_number\":\"${GITHUB_NAME}\"}}" | base64)
@@ -43,7 +42,7 @@ fi
 
 # Kafka queue
 # Get latest release URL at https://kafka.apache.org/quickstart
-export KAFKA_INSTALL_URL="http://mirror.dkm.cz/apache/kafka/2.2.0/kafka_2.12-2.2.0.tgz"
+export KAFKA_INSTALL_URL="http://mirror.dkm.cz/apache/kafka/2.4.0/kafka_2.12-2.4.0.tgz"
 # Directory below is created automatically by script install.sh
 export KAFKA_DIR="$root_dir/kafka"
 export QUEUE_HOST="localhost" # used by openshift-operations

--- a/scripts/config.default.sh
+++ b/scripts/config.default.sh
@@ -26,6 +26,11 @@ export MY_GITHUB_NAME="" # https://github.com/<MY_GITHUB_NAME>/<repository name>
 # https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line
 export MY_GITHUB_TOKEN=""
 
+# Account number is used to http auth header.
+# It equals Tenant.external_tenant db value
+# If you log in to CI/QA/Prod server, you can see account number in dropbox under user name
+# Set to github_name for backwards compatibility
+export ACCOUNT_NUMBER=${MY_GITHUB_NAME}
 # Variable for HTTP request header x-rh-identity.
 # Requests authenticated against Tenant.external_tenant
 export X_RH_IDENTITY=$(echo "{\"identity\":{\"account_number\":\"${GITHUB_NAME}\"}}" | base64)

--- a/scripts/db/init-data.sh
+++ b/scripts/db/init-data.sh
@@ -11,11 +11,11 @@ bundle exec rake db:seed
 
 cd ${TOPOLOGICAL_API_DIR}
 echo "Creating Tenants"
-rails r "Tenant.find_or_create_by(:external_tenant => '$MY_GITHUB_NAME')"
+rails r "Tenant.find_or_create_by(:external_tenant => '$ACCOUNT_NUMBER')"
 rails r "Tenant.find_or_create_by(:external_tenant => 'system_orchestrator')"
 
 cd ${SOURCES_API_DIR}
-rails r "Tenant.find_or_create_by(:name => '$MY_GITHUB_NAME', :external_tenant => '$MY_GITHUB_NAME')"
+rails r "Tenant.find_or_create_by(:name => '$ACCOUNT_NUMBER', :external_tenant => '$ACCOUNT_NUMBER')"
 # sources-sync tenant hardcoded in topological_inventory-sync/lib/topological_inventory/sync/sources_sync_worker.rb:77
 rails r "Tenant.find_or_create_by(:name => 'Tp-Inv Sources Sync service', :external_tenant => 'topological_inventory-sources_sync')"
 rails r "Tenant.find_or_create_by(:name => 'Orchestrator', :external_tenant => 'system_orchestrator')"
@@ -24,11 +24,11 @@ echo "Creating Mock Source Type"
 rails r "SourceType.find_or_create_by(:name => 'mock-source', :product_name => 'Mock', :vendor => 'Red Hat')"
 
 echo "Setting Mock Source to: $MOCK_SOURCE_UID"
-rails r "Source.find_or_create_by(:name => 'Mock Source', :tenant => Tenant.where(:external_tenant => '$MY_GITHUB_NAME').first, :uid =>'$MOCK_SOURCE_UID', :source_type => SourceType.find_by(:name => 'mock-source'), :availability_status => 'available')"
+rails r "Source.find_or_create_by(:name => 'Mock Source', :tenant => Tenant.where(:external_tenant => '$ACCOUNT_NUMBER').first, :uid =>'$MOCK_SOURCE_UID', :source_type => SourceType.find_by(:name => 'mock-source'), :availability_status => 'available')"
 
 # Token(Password) has to be added manually!
 echo "Setting Openshift Source to: $OPENSHIFT_SOURCE_UID"
-rails r "tenant = Tenant.where(:external_tenant => '$MY_GITHUB_NAME').first
+rails r "tenant = Tenant.where(:external_tenant => '$ACCOUNT_NUMBER').first
 src = Source.find_or_create_by(:name => 'OpenShift Source', :tenant => tenant, :uid =>'$OPENSHIFT_SOURCE_UID', :source_type => SourceType.find_by(:name => 'openshift'), :availability_status => 'available')
 endpoint = Endpoint.find_or_create_by(:source_id => src.id, :port => $OPENSHIFT_PORT, :default => true, :scheme => '$OPENSHIFT_SCHEME', :host => '$OPENSHIFT_HOST', :path => '/', :tenant => tenant)
 auth = Authentication.find_or_create_by(:resource_type => 'Endpoint', :resource_id => endpoint.id, :authtype => 'token', :password =>'xxx', :tenant => tenant)
@@ -37,7 +37,7 @@ app = Application.find_or_create_by(:source => src, :tenant => tenant, :applicat
 
 
 echo "Setting Amazon Source to: $AMAZON_SOURCE_UID"
-rails r "tenant = Tenant.where(:external_tenant => '$MY_GITHUB_NAME').first
+rails r "tenant = Tenant.where(:external_tenant => '$ACCOUNT_NUMBER').first
 src = Source.find_or_create_by(:name => 'Amazon Source', :tenant => tenant, :uid =>'$AMAZON_SOURCE_UID', :source_type => SourceType.find_by(:name => 'amazon'), :availability_status => 'available')
 endpoint = Endpoint.find_or_create_by(:source_id => src.id, :default => true, :path => '/', :tenant => tenant)
 auth = Authentication.find_or_create_by(:resource_type => 'Endpoint', :resource_id => endpoint.id, :authtype => 'access_key_secret_key', :username => '$AMAZON_ACCESS_KEY_ID', :password => '$AMAZON_SECRET_ACCESS_KEY', :tenant => tenant)
@@ -45,7 +45,7 @@ app_type = ApplicationType.where(:name => '/insights/platform/topological-invent
 app = Application.find_or_create_by(:source => src, :tenant => tenant, :application_type => app_type, :availability_status => 'available')"
 
 echo "Setting AnsibleTower Source to: $ANSIBLE_TOWER_SOURCE_UID"
-rails r "tenant = Tenant.where(:external_tenant => '$MY_GITHUB_NAME').first
+rails r "tenant = Tenant.where(:external_tenant => '$ACCOUNT_NUMBER').first
 src = Source.find_or_create_by(:name => 'Ansible Tower Source', :tenant => tenant, :uid => '$ANSIBLE_TOWER_SOURCE_UID', :source_type => SourceType.find_by(:name => 'ansible-tower'), :availability_status => 'available')
 endpoint = Endpoint.find_or_create_by(:source_id => src.id, :role => 'ansible', :default => true, :scheme => '$ANSIBLE_TOWER_SCHEME', :host => '$ANSIBLE_TOWER_HOST', :path => '/', :tenant => tenant)
 auth = Authentication.find_or_create_by(:resource_type => 'Endpoint', :resource_id => endpoint.id, :authtype => 'username_password', :username => '$ANSIBLE_TOWER_USER', :password => '$ANSIBLE_TOWER_PASSWORD', :tenant => tenant)
@@ -53,7 +53,7 @@ app_type = ApplicationType.where(:name => '/insights/platform/topological-invent
 app = Application.find_or_create_by(:source => src, :tenant => tenant, :application_type => app_type, :availability_status => 'available')"
 
 echo "Setting Azure Source to: $AZURE_SOURCE_UID"
-rails r "tenant = Tenant.where(:external_tenant => '$MY_GITHUB_NAME').first
+rails r "tenant = Tenant.where(:external_tenant => '$ACCOUNT_NUMBER').first
 src = Source.find_or_create_by(:name => 'Azure Source', :tenant => tenant, :uid =>'$AZURE_SOURCE_UID', :source_type => SourceType.find_by(:name => 'azure'), :availability_status => 'available')
 endpoint = Endpoint.find_or_create_by(:source_id => src.id, :default => true, :path => '/', :tenant => tenant)
 auth = Authentication.find_or_create_by(:resource_type => 'Endpoint', :resource_id => endpoint.id, :authtype => 'tenant_id_client_id_client_secret', :username => '$AZURE_CLIENT_ID', :password => '$AZURE_CLIENT_SECRET', :extra => {\"azure\": {\"tenant_id\": \"$AZURE_SUBSCRIPTION_ID\"}}, :tenant => tenant)

--- a/scripts/git/clone.sh
+++ b/scripts/git/clone.sh
@@ -18,7 +18,11 @@ cd ${root_dir}
 
 for name in ${repositories[@]} 
 do
-  upstream_org="RedHatInsights"
+    if [[ ${name} == "inventory_refresh" ]]; then
+        upstream_org="ManageIQ"
+    else
+        upstream_org="RedHatInsights"
+    fi
 
 	echo "----------------------------------------------------------------------"
 	#

--- a/scripts/services/mock-collector-insights-upload.sh
+++ b/scripts/services/mock-collector-insights-upload.sh
@@ -6,4 +6,4 @@ source init-common.sh
 cd $MOCK_SOURCE_DIR
 bin/mock-collector-insights-upload --source $MOCK_SOURCE_UID --config $MOCK_SOURCE_CONFIG --data $MOCK_SOURCE_DATA \
 --insights-upload-api="http://localhost:8888" --insights-upload-base-path="api/ingress/v1/upload" \
---tenant=$MY_GITHUB_NAME
+--tenant=$ACCOUNT_NUMBER

--- a/scripts/services/ui.sh
+++ b/scripts/services/ui.sh
@@ -7,4 +7,4 @@ echo "Starting UI"
 echo "See https://ci.foo.redhat.com:1337/insights/settings/sources"
 
 cd ${SOURCES_UI_DIR}
-FAKE_IDENTITY=${MY_GITHUB_NAME} BASE_PATH=http://${SOURCES_HOST}:${SOURCES_PORT}/api npm run start
+FAKE_IDENTITY=${ACCOUNT_NUMBER} BASE_PATH=http://${SOURCES_HOST}:${SOURCES_PORT}/api npm run start


### PR DESCRIPTION
Account number (alias external_tenant) was taken from github name. It works until you decide using insights-proxy. Then you need to set your tenant as account number you log in to server.