### PR TITLE
Script for finding Source in ConfigMaps by Source ID

### DIFF
--- a/scripts/openshift/find-source.sh
+++ b/scripts/openshift/find-source.sh
@@ -1,0 +1,18 @@
+#!/bin/bash --login
+
+# Usage:
+# You have to be logged in to openshift and switched to your project [namespace]
+#
+# Then find-source.sh <source-id>
+
+source_id=$1
+
+maps=$(oc get configmaps -l tp-inventory/collectors-config-map=true --no-headers | awk '{print $1}')
+
+for map in ${maps[@]}
+do
+  found=$(oc describe configmap ${map} | grep ":source_id: '${source_id}'")
+  if [[ -n $found ]]; then
+    echo ${map}
+  fi
+done


### PR DESCRIPTION
Usage: `find-source.sh <source-id>`

You have to be logged in to openshift and switched to your project [namespace]

Returns name of config map or nothing