### PR TITLE
Finding Source in ConfigMaps regardless of label value

### DIFF
--- a/scripts/openshift/find-source.sh
+++ b/scripts/openshift/find-source.sh
@@ -7,7 +7,7 @@
 
 source_id=$1
 
-maps=$(oc get configmaps -l tp-inventory/collectors-config-map=true --no-headers | awk '{print $1}')
+maps=$(oc get configmaps -l tp-inventory/collectors-config-map --no-headers | awk '{print $1}')
 
 for map in ${maps[@]}
 do


### PR DESCRIPTION
label `tp-inventory/collectors-config-map`'s value was updated to `v1`. But the value is not important here.