### PR TITLE
Sources-sync 5s waiting for other services

### DIFF
--- a/scripts/services/sources-sync.sh
+++ b/scripts/services/sources-sync.sh
@@ -5,4 +5,6 @@ source config.sh
 source init-common.sh
 
 cd ${TOPOLOGICAL_INVENTORY_SYNC_DIR}
+
+sleep 5 # Waiting for API init
 bin/topological-inventory-sources-sync


### PR DESCRIPTION
Sources-sync crashes in the first run when started together  with other services (in tmux)
Probably APIs or Kafka are not initialized at this moment.

5s waiting at the start solved this problem 