### PR TITLE
Fixed bug in start.sh

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -8,7 +8,7 @@ source ./init-common.sh
 
 requested_svc=$1
 
-[ -n "$LOG_DIR" ] && [ [ -d "$LOG_DIR" ] || mkdir -p "$LOG_DIR" ]
+[ -n "$LOG_DIR" ] && ( [ -d "$LOG_DIR" ] || mkdir -p "$LOG_DIR" )
 
 if [[ -z ${requested_svc} ]]; then
 


### PR DESCRIPTION
Fixed a bug in start.sh that resulted in the creation of an empty directory named "]".