### PR TITLE
Enable starting a single service before starting the rest.

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -50,7 +50,12 @@ if [[ -z ${requested_svc} ]]; then
 
 	tmux attach-session -t TpInv
 else
-                echo "(Re)starting $requested_svc"
-                stop_svc_in_tmux ${requested_svc}
-                start_svc_in_tmux ${requested_svc}
+    tmux has-session -t TpInv
+    if [ $? != 0 ]; then
+        tmux new-session -d -s TpInv
+    fi
+    
+    echo "(Re)starting $requested_svc"
+    stop_svc_in_tmux ${requested_svc}
+    start_svc_in_tmux ${requested_svc}
 fi


### PR DESCRIPTION
Sometimes, we may want to start a single service, like Kafka, before we start the rest of the services.
Normally when a single service is started, it assumes  the tmux session already exists. Now, we'll create the session if it doesn't exist.