### PR TITLE
Updates for quay.sh

### DIFF
--- a/scripts/clowder/README.md
+++ b/scripts/clowder/README.md
@@ -82,4 +82,3 @@ If you want to use images from your local source code, follow these steps:
       - NOTE: For Mac OS is recommended `docker`
     - third parameter determines whether image is build from cache: value is `no-cache` - without cache (default is with cache)  
      - i.e. `cd ~/Projects/RedHatInsights/sources-api; ../scripts/clowder/quay.sh sources-api docker no-cache`
- 

--- a/scripts/clowder/README.md
+++ b/scripts/clowder/README.md
@@ -74,11 +74,11 @@ If you want to use images from your local source code, follow these steps:
 - remove `.bundle` directory from your local repository
 - run `export QUAY_ROOT="quay.io/<user>"`
     - i.e. `export QUAY_ROOT="quay.io/mslemr"`
-- run `cd <your local repository>; ../scripts/clowder/quay.sh <quay repository`
+- run `cd <your local repository>; ../scripts/clowder/quay.sh <quay repository>`
     - i.e `cd ~/Projects/RedHatInsights/sources-api; ../scripts/clowder/quay.sh sources-api`
-    - it returns the IMAGE_TAG value  
+    - it returns the IMAGE_TAG value
     - set env variable IMAGE_BUILDER determine which command is used to build images, supported values are `podman` or `docker` (Default is `docker`).
-      - i.e. `cd ~/Projects/RedHatInsights/sources-api; env IMAGE_BUILDER=docker ../scripts/clowder/quay.sh sources-api docker`
+      - i.e. `cd ~/Projects/RedHatInsights/sources-api; env IMAGE_BUILDER=docker ../scripts/clowder/quay.sh sources-api`
       - NOTE: For Mac OS is recommended `docker`
-    - third parameter determines whether image is build from cache: value is `no-cache` - without cache (default is with cache)  
-     - i.e. `cd ~/Projects/RedHatInsights/sources-api; ../scripts/clowder/quay.sh sources-api docker no-cache`
+    - set env variable CACHE which determines whether image is build from cache: value is `no-cache` - without cache (default is with cache)
+     - i.e. `cd ~/Projects/RedHatInsights/sources-api; env CACHE=no-cache ../scripts/clowder/quay.sh sources-api`

--- a/scripts/clowder/README.md
+++ b/scripts/clowder/README.md
@@ -77,3 +77,6 @@ If you want to use images from your local source code, follow these steps:
 - run `cd <your local repository>; ../scripts/clowder/quay.sh <quay repository`
     - i.e `cd ~/Projects/RedHatInsights/sources-api; ../scripts/clowder/quay.sh sources-api`
     - it returns the IMAGE_TAG value  
+    - second parameter is pod manager, acceptable value is `podman` or `docker` (Default is `docker`).
+      - i.e. `cd ~/Projects/RedHatInsights/sources-api; ../scripts/clowder/quay.sh sources-api docker` 
+  

--- a/scripts/clowder/README.md
+++ b/scripts/clowder/README.md
@@ -77,8 +77,9 @@ If you want to use images from your local source code, follow these steps:
 - run `cd <your local repository>; ../scripts/clowder/quay.sh <quay repository`
     - i.e `cd ~/Projects/RedHatInsights/sources-api; ../scripts/clowder/quay.sh sources-api`
     - it returns the IMAGE_TAG value  
-    - second parameter is pod manager, acceptable value is `podman` or `docker` (Default is `docker`).
-      - i.e. `cd ~/Projects/RedHatInsights/sources-api; ../scripts/clowder/quay.sh sources-api docker`
+    - set env variable IMAGE_BUILDER determine which command is used to build images, supported values are `podman` or `docker` (Default is `docker`).
+      - i.e. `cd ~/Projects/RedHatInsights/sources-api; env IMAGE_BUILDER=docker ../scripts/clowder/quay.sh sources-api docker`
+      - NOTE: For Mac OS is recommended `docker`
     - third parameter determines whether image is build from cache: value is `no-cache` - without cache (default is with cache)  
      - i.e. `cd ~/Projects/RedHatInsights/sources-api; ../scripts/clowder/quay.sh sources-api docker no-cache`
  

--- a/scripts/clowder/README.md
+++ b/scripts/clowder/README.md
@@ -78,5 +78,7 @@ If you want to use images from your local source code, follow these steps:
     - i.e `cd ~/Projects/RedHatInsights/sources-api; ../scripts/clowder/quay.sh sources-api`
     - it returns the IMAGE_TAG value  
     - second parameter is pod manager, acceptable value is `podman` or `docker` (Default is `docker`).
-      - i.e. `cd ~/Projects/RedHatInsights/sources-api; ../scripts/clowder/quay.sh sources-api docker` 
-  
+      - i.e. `cd ~/Projects/RedHatInsights/sources-api; ../scripts/clowder/quay.sh sources-api docker`
+    - third parameter determines whether image is build from cache: value is `no-cache` - without cache (default is with cache)  
+     - i.e. `cd ~/Projects/RedHatInsights/sources-api; ../scripts/clowder/quay.sh sources-api docker no-cache`
+ 

--- a/scripts/clowder/quay.sh
+++ b/scripts/clowder/quay.sh
@@ -7,8 +7,22 @@ if [[ -z $QUAY_ROOT ]]; then
   exit
 fi
 
+if [[ "$(uname)" == "Darwin" ]]; then
+  MAC_OS=true
+else
+  MAC_OS=false
+fi
+
 svc=$1
-image_tag=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1`
+
+IMAGE_COMMAND="cat /dev/urandom |"
+
+if $MAC_OS; then
+  IMAGE_COMMAND="${IMAGE_COMMAND} LC_CTYPE=C"
+fi
+
+IMAGE_COMMAND="${IMAGE_COMMAND} tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1"
+image_tag=`eval "$IMAGE_COMMAND"`
 
 #BUILDAH_LAYERS=false podman build -t ${QUAY_ROOT}/${svc} . # don't use cached layers
 podman build -t ${QUAY_ROOT}/${svc} .

--- a/scripts/clowder/quay.sh
+++ b/scripts/clowder/quay.sh
@@ -13,7 +13,18 @@ else
   MAC_OS=false
 fi
 
-PODMANAGER="docker"
+PODMANAGER="podman"
+
+if [[ -n $2 ]]; then
+  PODMANAGER=$2
+
+  if [[ $2 != "docker" ]] && [[ $2 != "podman" ]]; then
+    echo "Second parameter have to be podman or docker."
+    exit 2
+  fi
+fi
+
+echo "Used pod manager: $PODMANAGER"
 
 svc=$1
 

--- a/scripts/clowder/quay.sh
+++ b/scripts/clowder/quay.sh
@@ -25,10 +25,10 @@ fi
 
 echo "Used image builder: $IMAGE_BUILDER"
 
-CACHE=true
-
-if [[ $3 == "no-cache" ]]; then
+if [[ $CACHE == "no-cache" ]]; then
   CACHE=false
+else
+  CACHE=true
 fi
 
 svc=$1
@@ -45,7 +45,7 @@ image_tag=`eval "$IMAGE_COMMAND"`
 if $CACHE; then
   $IMAGE_BUILDER build -t ${QUAY_ROOT}/${svc} .
 else
-  if [[ IMAGE_BUILDER == "podman" ]]; then
+  if [[ $IMAGE_BUILDER == "podman" ]]; then
     BUILDAH_LAYERS=false podman build -t ${QUAY_ROOT}/${svc} . # don't use cached layers
   else
     docker build -t ${QUAY_ROOT}/${svc} . --no-cache

--- a/scripts/clowder/quay.sh
+++ b/scripts/clowder/quay.sh
@@ -13,15 +13,14 @@ else
   MAC_OS=false
 fi
 
-IMAGE_BUILDER="podman"
 
-if [[ -n $2 ]]; then
-  IMAGE_BUILDER=$2
+if [[ -z $IMAGE_BUILDER ]]; then
+  IMAGE_BUILDER="podman"
+fi
 
-  if [[ $2 != "docker" ]] && [[ $2 != "podman" ]]; then
-    echo "Second parameter have to be podman or docker."
-    exit 2
-  fi
+if [[ $IMAGE_BUILDER != "docker" ]] && [[ $IMAGE_BUILDER != "podman" ]]; then
+  echo "IMAGE_BUILDER has to be 'podman' or 'docker'."
+  exit 2
 fi
 
 echo "Used image builder: $IMAGE_BUILDER"

--- a/scripts/clowder/quay.sh
+++ b/scripts/clowder/quay.sh
@@ -13,6 +13,8 @@ else
   MAC_OS=false
 fi
 
+PODMANAGER="docker"
+
 svc=$1
 
 IMAGE_COMMAND="cat /dev/urandom |"
@@ -25,12 +27,12 @@ IMAGE_COMMAND="${IMAGE_COMMAND} tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1"
 image_tag=`eval "$IMAGE_COMMAND"`
 
 #BUILDAH_LAYERS=false podman build -t ${QUAY_ROOT}/${svc} . # don't use cached layers
-podman build -t ${QUAY_ROOT}/${svc} .
-podman run -d ${QUAY_ROOT}/${svc}
-container_id=`podman ps -l | grep "${QUAY_ROOT}/${svc}" | awk '{print $1}'`
+$PODMANAGER build -t ${QUAY_ROOT}/${svc} .
 
-podman commit $container_id ${QUAY_ROOT}/${svc}
-podman tag ${QUAY_ROOT}/${svc} ${QUAY_ROOT}/${svc}:${image_tag} && podman push $_
+container_id=`$PODMANAGER run -d ${QUAY_ROOT}/${svc}`
+
+$PODMANAGER commit $container_id ${QUAY_ROOT}/${svc}
+$PODMANAGER tag ${QUAY_ROOT}/${svc} ${QUAY_ROOT}/${svc}:${image_tag} && $PODMANAGER push $_
 
 echo "Finished! --------------------------------------"
 echo "Quay Image: ${QUAY_ROOT}/${svc}"

--- a/scripts/clowder/quay.sh
+++ b/scripts/clowder/quay.sh
@@ -13,10 +13,10 @@ else
   MAC_OS=false
 fi
 
-PODMANAGER="podman"
+IMAGE_BUILDER="podman"
 
 if [[ -n $2 ]]; then
-  PODMANAGER=$2
+  IMAGE_BUILDER=$2
 
   if [[ $2 != "docker" ]] && [[ $2 != "podman" ]]; then
     echo "Second parameter have to be podman or docker."
@@ -24,7 +24,7 @@ if [[ -n $2 ]]; then
   fi
 fi
 
-echo "Used pod manager: $PODMANAGER"
+echo "Used image builder: $IMAGE_BUILDER"
 
 CACHE=true
 
@@ -44,19 +44,19 @@ IMAGE_COMMAND="${IMAGE_COMMAND} tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1"
 image_tag=`eval "$IMAGE_COMMAND"`
 
 if $CACHE; then
-  $PODMANAGER build -t ${QUAY_ROOT}/${svc} .
+  $IMAGE_BUILDER build -t ${QUAY_ROOT}/${svc} .
 else
-  if [[ PODMANAGER == "podman" ]]; then
+  if [[ IMAGE_BUILDER == "podman" ]]; then
     BUILDAH_LAYERS=false podman build -t ${QUAY_ROOT}/${svc} . # don't use cached layers
   else
     docker build -t ${QUAY_ROOT}/${svc} . --no-cache
   fi
 fi
 
-container_id=`$PODMANAGER run -d ${QUAY_ROOT}/${svc}`
+container_id=`$IMAGE_BUILDER run -d ${QUAY_ROOT}/${svc}`
 
-$PODMANAGER commit $container_id ${QUAY_ROOT}/${svc}
-$PODMANAGER tag ${QUAY_ROOT}/${svc} ${QUAY_ROOT}/${svc}:${image_tag} && $PODMANAGER push $_
+$IMAGE_BUILDER commit $container_id ${QUAY_ROOT}/${svc}
+$IMAGE_BUILDER tag ${QUAY_ROOT}/${svc} ${QUAY_ROOT}/${svc}:${image_tag} && $IMAGE_BUILDER push $_
 
 echo "Finished! --------------------------------------"
 echo "Quay Image: ${QUAY_ROOT}/${svc}"


### PR DESCRIPTION
- reflect Mac OS operating system to fix image tag generation
- possibility to switch between pod managers: `docker` or `podman` - for Mac is recommended docker
   -  `env IMAGE_BUILDER=docker ../scripts/clowder/quay.sh sources-api`
   -  `env IMAGE_BUILDER=podman ../scripts/clowder/quay.sh sources-api`
- possibility to build image without cache:
  -  `env CACHE=no-cache ../scripts/clowder/quay.sh sources-api`

cc @slemrmartin 
